### PR TITLE
TASK: Add "ComplexAttribute" model

### DIFF
--- a/Classes/Netlogix/JsonApiOrg/Domain/Model/ComplexAttribute.php
+++ b/Classes/Netlogix/JsonApiOrg/Domain/Model/ComplexAttribute.php
@@ -1,0 +1,7 @@
+<?php
+namespace Netlogix\JsonApiOrg\Domain\Model;
+
+interface ComplexAttribute
+{
+
+}


### PR DESCRIPTION
Sometimes its convenient to have structures as attributes of
objects that are no relations, like `credentialsi` that are both,
`username` and `password`, or sometimes just to provide a place for
validation rules.

This interface automatically allows all sub properties to be
mapped.