### PR TITLE
BUGFIX: Reuse existing controller context instead of creating a new one

### DIFF
--- a/Classes/Netlogix/JsonApiOrg/Controller/ApiController.php
+++ b/Classes/Netlogix/JsonApiOrg/Controller/ApiController.php
@@ -68,6 +68,13 @@ abstract class ApiController extends RestController
      */
     protected $relationshipArgumentName = 'relationshipName';
 
+    public function callActionMethod()
+    {
+        return $this->resourceMapper->withinControllerContext($this->controllerContext, function() {
+            return parent::callActionMethod();
+        });
+    }
+
     /**
      * Determines the action method and assures that the method exists.
      *

--- a/Classes/Netlogix/JsonApiOrg/Resource/Information/ResourceMapper.php
+++ b/Classes/Netlogix/JsonApiOrg/Resource/Information/ResourceMapper.php
@@ -78,7 +78,6 @@ class ResourceMapper
      */
     public function initializeObject()
     {
-        $this->initializeControllerContext();
         $this->initializeConverters();
     }
 
@@ -170,31 +169,6 @@ class ResourceMapper
     }
 
     /**
-     * The Resource Information most likely needs an UriBuilder, so having a
-     * ControllerContext in place might come in handy.
-     *
-     * @return void
-     */
-    protected function initializeControllerContext()
-    {
-
-        $request = new ActionRequest(Request::createFromEnvironment());
-        $request->setDispatched(true);
-        if (isset($this->flowHttpSettings['baseUri'])) {
-            $request->getHttpRequest()->setBaseUri(new Uri($this->flowHttpSettings['baseUri']));
-        }
-
-        $response = new Response();
-
-        $uriBuilder = new UriBuilder();
-        $uriBuilder->setRequest($request);
-
-        $arguments = new Arguments(array());
-
-        $this->controllerContext = new ControllerContext($request, $response, $arguments, $uriBuilder);
-    }
-
-    /**
      * @return void
      */
     protected function initializeConverters()
@@ -213,6 +187,17 @@ class ResourceMapper
                     return $first->getPriority() < $second->getPriority();
                 }
             });
+    }
+
+    public function withinControllerContext(ControllerContext $controllerContext, callable $scope)
+    {
+        try {
+            $before = $this->controllerContext;
+            $this->controllerContext = $controllerContext;
+            return $scope();
+        } finally {
+            $this->controllerContext = $before;
+        }
     }
 
 }


### PR DESCRIPTION
The ResourceMapper is the one in charge for creating all kinds of URIs,
like the self link of an entity or the relation links.

This change makes the ResourceMapper not create a new ControllerContext
but rely on external data during its rendering time.

The ApiController, in turn, is the one passing the ControllerContext
which is currently active along.