### PR TITLE
FEATURE: Allow POST requests containing "included" entities

### DIFF
--- a/Classes/Netlogix/JsonApiOrg/Controller/ApiController.php
+++ b/Classes/Netlogix/JsonApiOrg/Controller/ApiController.php
@@ -140,8 +140,10 @@ abstract class ApiController extends RestController
                     if (!isset($arguments[$this->resourceArgumentName])) {
                         $arguments[$this->resourceArgumentName] = [];
                     }
-                    $arguments[$this->resourceArgumentName] = array_merge_recursive($arguments[$this->resourceArgumentName],
-                        $this->extractRequestBody());
+                    $arguments[$this->resourceArgumentName] = array_merge_recursive(
+                        $arguments[$this->resourceArgumentName],
+                        $this->extractRequestBody()
+                    );
                     $this->request->setArguments($arguments);
                     break;
             }
@@ -160,12 +162,20 @@ abstract class ApiController extends RestController
     {
         $propertyMappingConfiguration = new PropertyMappingConfiguration();
         $propertyMappingConfiguration->setTypeConverter($this->objectManager->get(MediaTypeConverterInterface::class));
-        $propertyMappingConfiguration->setTypeConverterOption(MediaTypeConverterInterface::class,
-            MediaTypeConverterInterface::CONFIGURATION_MEDIA_TYPE, 'application/json');
-        $result = $this->objectManager->get(PropertyMapper::class)->convert($this->request->getHttpRequest()->getContent(),
-            'array', $propertyMappingConfiguration);
-
-        return $result['data'];
+        $propertyMappingConfiguration->setTypeConverterOption(
+            MediaTypeConverterInterface::class,
+            MediaTypeConverterInterface::CONFIGURATION_MEDIA_TYPE,
+            'application/json'
+        );
+        $result = $this
+            ->objectManager
+            ->get(PropertyMapper::class)
+            ->convert(
+                (string)$this->request->getHttpRequest()->getBody(),
+                'array',
+                $propertyMappingConfiguration
+            );
+        return array_intersect_key($result, array_flip(['data', 'included']));
     }
 
     /**

--- a/Classes/Netlogix/JsonApiOrg/Property/TypeConverter/Entity/CollectionRelationshipConverter.php
+++ b/Classes/Netlogix/JsonApiOrg/Property/TypeConverter/Entity/CollectionRelationshipConverter.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Netlogix\JsonApiOrg\Property\TypeConverter\Entity;
+
+/*
+ * This file is part of the Netlogix.JsonApiOrg package.
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Neos\Flow\Property\PropertyMappingConfigurationInterface;
+
+/**
+ */
+class CollectionRelationshipConverter extends AbstractSchemaResourceBasedEntityConverter
+{
+    /**
+     * @var integer
+     */
+    protected $priority = 1457600399;
+
+    /**
+     * @var array
+     */
+    protected $sourceTypes = ['array'];
+
+    /**
+     * @var string
+     */
+    protected $targetType = Collection::class;
+
+    public function canConvertFrom($source, $targetType)
+    {
+        if (!is_array($source)
+            || !array_key_exists('data', $source)
+            || !is_array($source['data'])
+        ) {
+            return false;
+        }
+        foreach ($source['data'] as $data) {
+            if (!$this->hasOnlyIdentifierProperties($data)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public function convertFrom(
+        $source,
+        $targetType,
+        array $convertedChildProperties = [],
+        PropertyMappingConfigurationInterface $configuration = null
+    ) {
+        return new ArrayCollection(
+            array_map(
+                function ($data) {
+                    return $this->convertIdentifierProperties($data);
+                },
+                $source['data']
+            )
+        );
+    }
+
+}

--- a/Classes/Netlogix/JsonApiOrg/Property/TypeConverter/Entity/PersistentObjectFromTopLevelArrayConverter.php
+++ b/Classes/Netlogix/JsonApiOrg/Property/TypeConverter/Entity/PersistentObjectFromTopLevelArrayConverter.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Netlogix\JsonApiOrg\Property\TypeConverter\Entity;
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Property\Exception as PropertyException;
+use Neos\Flow\Property\PropertyMapper;
+use Neos\Flow\Property\PropertyMappingConfigurationInterface;
+
+class PersistentObjectFromTopLevelArrayConverter extends PersistentObjectConverter
+{
+    const TARGET_TYPE = '__target_type';
+
+    protected $priority = 1565610123;
+
+    protected $sourceTypes = ['array'];
+
+    /**
+     * @Flow\Inject
+     * @var PropertyMapper
+     */
+    protected $propertyMapper;
+
+    /**
+     * Only convert non-persistent types
+     *
+     * @param mixed $source
+     * @param string $targetType
+     * @return boolean
+     */
+    public function canConvertFrom($source, $targetType)
+    {
+        if (
+            !is_array($source)
+            || !array_key_exists('data', $source)
+        ) {
+            return false;
+        }
+        foreach ($this->getFlatCandidatesArrayFromSource($source) as $candidate) {
+            if (!$this->canConvertSingleObject($candidate)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public function convertFrom(
+        $source,
+        $targetType,
+        array $convertedChildProperties = [],
+        PropertyMappingConfigurationInterface $configuration = null
+    ) {
+        $scoped = function (
+            $source,
+            $targetType,
+            array $convertedChildProperties = [],
+            PropertyMappingConfigurationInterface $configuration = null
+        ) {
+            $subject = $this->getSubjectFromSource($source);
+
+            $included = $this->getIncludedFromSource($source);
+            $included = $this->addTargetTypeToIncluded($included);
+            // FIXME: Calcuate actual dependency graph here
+            $included = array_reverse($included);
+
+            $this->mapIncluded($included);
+
+            $target = $this->propertyMapper->convert($subject, $targetType, $configuration);
+            $this->addToScope($subject, $target);
+
+            return $target;
+        };
+        return $this->asBatchScope($scoped, $source, $targetType, $convertedChildProperties, $configuration);
+    }
+
+    protected function mapIncluded(array $included)
+    {
+        while ($included !== []) {
+            $countBefore = count($included);
+            $included = array_filter($included, function (array $candidate) {
+                try {
+                    $subject = $this->propertyMapper->convert($candidate, $candidate[self::TARGET_TYPE]);
+                    $this->addToScope($candidate, $subject);
+                    return false;
+                } catch (PropertyException $e) {
+                    return true;
+                }
+            });
+            $countAfter = count($included);
+            if ($countAfter === $countBefore) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    protected function getFlatCandidatesArrayFromSource(array $source)
+    {
+        return array_merge(
+            [$this->getSubjectFromSource($source)],
+            $this->getIncludedFromSource($source)
+        );
+    }
+
+    protected function getSubjectFromSource(array $source): array
+    {
+        return $source['data'];
+    }
+
+    protected function getIncludedFromSource(array $source): array
+    {
+        return $source['included'] ?? [];
+    }
+
+    protected function getNumberOfDependencies(array $data): int
+    {
+        return isset($data['relationships']) ? count($data['relationships']) : 0;
+    }
+
+    protected function addTargetTypeToIncluded(array $included)
+    {
+        return array_map(function (array $candidate) {
+            $targetType = $this->exposableTypeMap->getClassName($candidate['type']);
+            $candidate[self::TARGET_TYPE] = $targetType;
+            return $candidate;
+        }, $included);
+    }
+}


### PR DESCRIPTION
Currently all entities are passed through the Flow TypeConverter "as is".
Without additional configuration, this only works in a very specific
situation:

Only the primary resource gets passed to the action method. So as long
as no implicit child persistence is in place (default behavior for
every entity with no repository), changes to related data will go
unnoticed.

Without additional configuration, passing identifiers from the client
on object creation is forbidden. So creating new entities doesn't
work.

The current implementation is not jsonapi.org standard since there's
no specification for this behavior. However there's discussion around
that for quite some time.