### PR TITLE
FEATURE: Expose BatchScope as public API

### DIFF
--- a/Classes/Netlogix/JsonApiOrg/Property/TypeConverter/Entity/BatchScope.php
+++ b/Classes/Netlogix/JsonApiOrg/Property/TypeConverter/Entity/BatchScope.php
@@ -1,0 +1,64 @@
+<?php
+declare(strict_types=1);
+
+namespace Netlogix\JsonApiOrg\Property\TypeConverter\Entity;
+
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * @Flow\Proxy(false)
+ */
+class BatchScope
+{
+    protected static $instance;
+
+    protected $entities = [];
+
+    protected $isMute = false;
+
+    public static function wrap(callable $callable, ... $callableArguments)
+    {
+        $executor = function () use (&$callable, &$callableArguments) {
+            return $callable(... $callableArguments);
+        };
+
+        if (self::$instance) {
+            return $executor();
+        } else {
+            try {
+                self::$instance = new self();
+                return $executor();
+            } finally {
+                self::$instance = null;
+            }
+        }
+    }
+
+    public static function instance(): self
+    {
+        static $mute;
+        if (!$mute) {
+            $mute = new self();
+            $mute->isMute = true;
+        }
+        return self::$instance ?? $mute;
+    }
+
+    public function addObject(array $source, $subject): self
+    {
+        if (!$this->isMute && $subject) {
+            $this->entities[self::getScopeIdentifier($source)] = $subject;
+        }
+        return $this;
+    }
+
+    public function findObject(array $source)
+    {
+        return $this->entities[self::getScopeIdentifier($source)] ?? null;
+    }
+
+    protected static function getScopeIdentifier(array $source): string
+    {
+        return ($source['type'] ?? '') . PHP_EOL . ($source['id'] ?? '');
+    }
+}

--- a/Classes/Netlogix/JsonApiOrg/Property/TypeConverter/Entity/PersistentObjectConverter.php
+++ b/Classes/Netlogix/JsonApiOrg/Property/TypeConverter/Entity/PersistentObjectConverter.php
@@ -148,7 +148,7 @@ class PersistentObjectConverter extends AbstractSchemaResourceBasedEntityConvert
         }
 
         if (count($arguments) === 1 && array_key_exists('__identity', $arguments)) {
-            $result = $this->getFromScope($source);
+            $result = BatchScope::instance()->findObject($source);
             if ($result) {
                 return $result;
             }
@@ -156,7 +156,7 @@ class PersistentObjectConverter extends AbstractSchemaResourceBasedEntityConvert
 
         $targetType = $this->exposableTypeMap->getClassName($source['type']);
         $result = $this->propertyMapper->convert($arguments, $targetType, $configuration);
-        $this->addToScope($source, $result);
+        BatchScope::instance()->addObject($source, $result);
         return $result;
     }
 

--- a/Classes/Netlogix/JsonApiOrg/Property/TypeConverter/Entity/PersistentObjectFromTopLevelArrayConverter.php
+++ b/Classes/Netlogix/JsonApiOrg/Property/TypeConverter/Entity/PersistentObjectFromTopLevelArrayConverter.php
@@ -66,11 +66,11 @@ class PersistentObjectFromTopLevelArrayConverter extends PersistentObjectConvert
             $this->mapIncluded($included);
 
             $target = $this->propertyMapper->convert($subject, $targetType, $configuration);
-            $this->addToScope($subject, $target);
+            BatchScope::instance()->addObject($subject, $target);
 
             return $target;
         };
-        return $this->asBatchScope($scoped, $source, $targetType, $convertedChildProperties, $configuration);
+        return BatchScope::wrap($scoped, $source, $targetType, $convertedChildProperties, $configuration);
     }
 
     protected function mapIncluded(array $included)
@@ -80,7 +80,7 @@ class PersistentObjectFromTopLevelArrayConverter extends PersistentObjectConvert
             $included = array_filter($included, function (array $candidate) {
                 try {
                     $subject = $this->propertyMapper->convert($candidate, $candidate[self::TARGET_TYPE]);
-                    $this->addToScope($candidate, $subject);
+                    BatchScope::instance()->addObject($candidate, $subject);
                     return false;
                 } catch (PropertyException $e) {
                     return true;


### PR DESCRIPTION
The "batch scope" is used to track newly created objects within a
single POST request, added as "included" in the POST body.

They are automaticaly detected if an internal PersistentObjectConverter
is used to create entities.

If custom type converters are used to create value objects where
relationships aren't converd by flow defaults, those custom type
converters need at least read access to retrieve relationships.