### PR TITLE
BUGFIX: Do not catch PropertyException on map included objects

### DIFF
--- a/Classes/Netlogix/JsonApiOrg/Property/TypeConverter/Entity/PersistentObjectFromTopLevelArrayConverter.php
+++ b/Classes/Netlogix/JsonApiOrg/Property/TypeConverter/Entity/PersistentObjectFromTopLevelArrayConverter.php
@@ -77,23 +77,10 @@ class PersistentObjectFromTopLevelArrayConverter extends PersistentObjectConvert
 
     protected function mapIncluded(array $included)
     {
-        while ($included !== []) {
-            $countBefore = count($included);
-            $included = array_filter($included, function (array $candidate) {
-                try {
-                    $subject = $this->propertyMapper->convert($candidate, $candidate[self::TARGET_TYPE]);
-                    BatchScope::instance()->addObject($candidate, $subject);
-                    return false;
-                } catch (PropertyException $e) {
-                    return true;
-                }
-            });
-            $countAfter = count($included);
-            if ($countAfter === $countBefore) {
-                return false;
-            }
-        }
-        return true;
+        \array_walk($included, function($candidate) {
+            $subject = $this->propertyMapper->convert($candidate, $candidate[self::TARGET_TYPE]);
+            BatchScope::instance()->addObject($candidate, $subject);
+        });
     }
 
     protected function getFlatCandidatesArrayFromSource(array $source)


### PR DESCRIPTION
Otherwise potential error messages get lost (and other kind of strange exceptions will be thrown)