### PR TITLE
Allow for API versioning

### DIFF
--- a/Classes/Netlogix/JsonApiOrg/Property/TypeConverter/Entity/AbstractSchemaResourceBasedEntityConverter.php
+++ b/Classes/Netlogix/JsonApiOrg/Property/TypeConverter/Entity/AbstractSchemaResourceBasedEntityConverter.php
@@ -68,9 +68,12 @@ abstract class AbstractSchemaResourceBasedEntityConverter extends PersistentObje
             return $result;
         } else {
             $identifier = array_key_exists('id', $source) ? $source['id'] : [];
+            $targetType = $this->exposableTypeMap
+                ->getExposableTypeByVersionedTypeName($source['type'])
+                ->className;
             $result = $this->propertyMapper->convert(
                 $identifier,
-                $this->exposableTypeMap->getClassName($source['type'])
+                $targetType
             );
             BatchScope::instance()->addObject($source, $result);
             return $result;

--- a/Classes/Netlogix/JsonApiOrg/Property/TypeConverter/Entity/PersistentObjectConverter.php
+++ b/Classes/Netlogix/JsonApiOrg/Property/TypeConverter/Entity/PersistentObjectConverter.php
@@ -55,7 +55,9 @@ class PersistentObjectConverter extends AbstractSchemaResourceBasedEntityConvert
         if (!$this->canConvertSingleObject($source)) {
             return false;
         }
-        $className = $this->exposableTypeMap->getClassName($source['type']);
+        $className = $this->exposableTypeMap
+            ->getExposableTypeByVersionedTypeName($source['type'])
+            ->className;
         return (
             $className === $targetType
             || is_subclass_of($className, $targetType)
@@ -72,7 +74,9 @@ class PersistentObjectConverter extends AbstractSchemaResourceBasedEntityConvert
             return false;
         }
         try {
-            $className = $this->exposableTypeMap->getClassName($source['type']);
+            $className = $this->exposableTypeMap
+                ->getExposableTypeByVersionedTypeName($source['type'])
+                ->className;
         } catch (FormatNotSupportedException $e) {
             return false;
         }
@@ -160,7 +164,9 @@ class PersistentObjectConverter extends AbstractSchemaResourceBasedEntityConvert
             }
         }
 
-        $targetType = $this->exposableTypeMap->getClassName($source['type']);
+        $targetType = $this->exposableTypeMap
+            ->getExposableTypeByVersionedTypeName($source['type'])
+            ->className;
         $result = $this->propertyMapper->convert($arguments, $targetType, $configuration);
         BatchScope::instance()->addObject($source, $result);
         return $result;

--- a/Classes/Netlogix/JsonApiOrg/Property/TypeConverter/Entity/PersistentObjectFromTopLevelArrayConverter.php
+++ b/Classes/Netlogix/JsonApiOrg/Property/TypeConverter/Entity/PersistentObjectFromTopLevelArrayConverter.php
@@ -109,7 +109,9 @@ class PersistentObjectFromTopLevelArrayConverter extends PersistentObjectConvert
     protected function addTargetTypeToIncluded(array $included)
     {
         return array_map(function (array $candidate) {
-            $targetType = $this->exposableTypeMap->getClassName($candidate['type']);
+            $targetType = $this->exposableTypeMap
+                ->getExposableTypeByVersionedTypeName($candidate['type'])
+                ->className;
             $candidate[self::TARGET_TYPE] = $targetType;
             return $candidate;
         }, $included);

--- a/Classes/Netlogix/JsonApiOrg/Property/TypeConverter/SchemaResource/ResourceConverter.php
+++ b/Classes/Netlogix/JsonApiOrg/Property/TypeConverter/SchemaResource/ResourceConverter.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Netlogix\JsonApiOrg\Property\TypeConverter\SchemaResource;
 
 /*
@@ -12,6 +13,7 @@ namespace Netlogix\JsonApiOrg\Property\TypeConverter\SchemaResource;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Property\PropertyMappingConfigurationInterface;
 use Neos\Flow\Property\TypeConverter\AbstractTypeConverter;
+use Netlogix\JsonApiOrg\Schema\Resource;
 
 /**
  * The target type of this converter is any kind of Schema\Resource.
@@ -57,7 +59,7 @@ class ResourceConverter extends AbstractTypeConverter
      * @var string
      * @api
      */
-    protected $targetType = 'Netlogix\\JsonApiOrg\\Schema\\Resource';
+    protected $targetType = Resource::class;
 
     /**
      * @param mixed $source
@@ -72,7 +74,6 @@ class ResourceConverter extends AbstractTypeConverter
         array $convertedChildProperties = array(),
         PropertyMappingConfigurationInterface $configuration = null
     ) {
-
         if (is_string($source)) {
             $sourceArray = json_decode($source, true);
             $source = is_array($sourceArray) ? $sourceArray : ['id' => $source];
@@ -81,7 +82,9 @@ class ResourceConverter extends AbstractTypeConverter
         if (!array_key_exists('type', $source)) {
             $dummyPayload = $this->objectManager->get($targetType);
             $typeIdentifier = $dummyPayload->getType();
-            $source['type'] = $this->exposableTypeMap->getType($typeIdentifier);
+            $source['type'] = $this->exposableTypeMap
+                ->getExposableTypeByVersionedTypeName($typeIdentifier)
+                ->className;
         }
 
         if (array_key_exists('id', $source)) {
@@ -89,7 +92,13 @@ class ResourceConverter extends AbstractTypeConverter
         } else {
             $arguments = [];
         }
-        $payload = $this->propertyMapper->convert($arguments, $this->exposableTypeMap->getClassName($source['type']));
+
+        $payload = $this->propertyMapper->convert(
+            source: $arguments,
+            targetType: $this->exposableTypeMap
+                ->getExposableTypeByVersionedTypeName($source['type'])
+                ->className
+        );
 
         $resourceInformation = $this->resourceMapper->findResourceInformation($payload);
         $resource = $resourceInformation->getResource($payload);

--- a/Classes/Netlogix/JsonApiOrg/Resource/Information/ExposableType.php
+++ b/Classes/Netlogix/JsonApiOrg/Resource/Information/ExposableType.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Netlogix\JsonApiOrg\Resource\Information;
+
+
+use JsonSerializable;
+use Neos\Flow\Annotations as Flow;
+
+#[Flow\Proxy(false)]
+final class ExposableType implements JsonSerializable
+{
+    public function __construct(
+        public readonly string $className,
+        public readonly string $typeName,
+        public readonly ?string $apiVersion = null,
+        public readonly ?string $replaces = null,
+    ) {
+    }
+
+    public function getVersionType(): string
+    {
+        $result = $this->typeName;
+        if ($this->apiVersion && $this->apiVersion !== ExposableTypeMapInterface::NEXT_VERSION) {
+            $result .= '@' . $this->apiVersion;
+        }
+        return $result;
+    }
+
+    public function getVersionTypeForProperty(string $propertyName): string
+    {
+        return $this->getVersionType() . ':->' . $propertyName;
+    }
+
+    public function jsonSerialize(): string
+    {
+        return $this->getVersionType();
+    }
+}

--- a/Classes/Netlogix/JsonApiOrg/Resource/Information/ExposableTypeMap.php
+++ b/Classes/Netlogix/JsonApiOrg/Resource/Information/ExposableTypeMap.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Netlogix\JsonApiOrg\Resource\Information;
 
 /*
@@ -11,6 +12,8 @@ namespace Netlogix\JsonApiOrg\Resource\Information;
 
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Property\Exception\FormatNotSupportedException;
+
+use function vsprintf;
 
 /**
  * This class holds information about:
@@ -26,6 +29,7 @@ use Neos\Flow\Property\Exception\FormatNotSupportedException;
  */
 class ExposableTypeMap implements ExposableTypeMapInterface
 {
+    private static ?string $forcedApiVersion = null;
 
     /**
      * Key/Value pairs mapping an internal type identifier to a public type name.
@@ -38,24 +42,39 @@ class ExposableTypeMap implements ExposableTypeMapInterface
      *     'Neos\ContentRepository\Domain\Model\Node::Neos.Neos:ContentCollection' => 'collection-node',
      *   );
      *
-     * @var array<string>
+     * @var array<string, ExposableType>
      */
-    protected $classIdentifierToTypeNameMap = array();
+    private $classIdentifierToTypeNameMap = [];
 
     /**
-     * Key/Value pairs mapping a public type name to an internal class identifier.
-     *
      * Example:
+     *   [
+     *     'unstructured' => [
+     *       'v1' => new ExposableType(
+     *         className: 'Neos\ContentRepository\Domain\Model\Node',
+     *         typeName: 'unstructured',
+     *         apiVersion: 'v1'
+     *       )
+     *     ],
+     *     'content-node' => [
+     *        'v1' => new ExposableType(
+     *          className: 'Neos\ContentRepository\Domain\Model\Node',
+     *          typeName: 'content-node',
+     *          apiVersion: 'v1'
+     *        )
+     *      ],
+     *     'collection-node' => [
+     *        'v1' => new ExposableType(
+     *          className: 'Neos\ContentRepository\Domain\Model\Node',
+     *          typeName: 'collection-node',
+     *          apiVersion: 'v1'
+     *        )
+     *      ]
+     *   ];
      *
-     *   array(
-     *     'unstructured' => 'Neos\ContentRepository\Domain\Model\Node'
-     *     'content-node' => 'Neos\ContentRepository\Domain\Model\Node'
-     *     'collection-node' => 'Neos\ContentRepository\Domain\Model\Node'
-     *   );
-     *
-     * @var array<string>
+     * @var array<array<string, ExposableType>>
      */
-    protected $typeNameToClassIdentifierMap = array();
+    private $typeNameToClassIdentifierMap = [];
 
     /**
      * Key/Value pairs mapping public properties of type names to class names
@@ -64,77 +83,112 @@ class ExposableTypeMap implements ExposableTypeMapInterface
      *
      * Example:
      *
-     *   array(
-     *     'unstructured->options' => 'array<string>',
-     *     'unstructured->firstname' => 'string',
-     *   );
+     *   [
+     *     'unstructured@v1->options' => 'array<string>',
+     *     'unstructured@v1->firstname' => 'string',
+     *   ];
      */
-    protected $typeAndPropertyNameToClassIdentifierMap = array();
+    private $typeAndPropertyNameToClassIdentifierMap = [];
 
     /**
-     * Key/Value pairs mapping an actual PHP class name to a public type name.
-     *
-     * @var array
+     * @template T of class-string
+     * @var array<T, ExposableType>
      */
-    protected $oneToOneTypeToClassMap = array();
+    private $oneToOneTypeToClassMap = [];
 
-    /**
-     *
-     */
-    public function initializeObject()
+    public function registerExposableType(ExposableType $exposableType): void
     {
-        foreach ($this->oneToOneTypeToClassMap as $className => $typeName) {
-            $this->typeNameToClassIdentifierMap[$typeName] = $className;
-            $this->classIdentifierToTypeNameMap[$className] = $typeName;
+        $this->classIdentifierToTypeNameMap[$exposableType->className] = $exposableType;
+
+        if (array_key_exists($exposableType->getVersionType(), $this->oneToOneTypeToClassMap)) {
+            // FIXME: Conflict resolution isn't quite there, yet, because multiple levels of replacement are not handled.
+            $conflict = $this->oneToOneTypeToClassMap[$exposableType->getVersionType()];
+            if ($conflict->replaces === $exposableType->className) {
+                // Conflict is already the "better" one
+                return;
+            } elseif ($conflict->replaces === $exposableType->className) {
+                // the new one is the "better" one
+            } else {
+                throw new \RuntimeException(
+                    vsprintf(
+                        'There is already an ExposableType registered for type "%s" (%s::class, %s::class)',
+                        [
+                            $exposableType->getVersionType(),
+                            $exposableType->className,
+                            $conflict->className,
+                        ]
+                    ),
+                    1758557659
+                );
+            }
         }
+        $this->oneToOneTypeToClassMap[$exposableType->getVersionType()] = $exposableType;
+        $this->typeNameToClassIdentifierMap[$exposableType->typeName] = $this->typeNameToClassIdentifierMap[$exposableType->typeName] ?? [];
+        $this->typeNameToClassIdentifierMap[$exposableType->typeName][$exposableType->apiVersion] = $exposableType;
     }
 
-    /**
-     * Returns the public type string for a given class name.
-     *
-     * @param string $classIdentifier
-     * @return string
-     * @throws FormatNotSupportedException
-     */
-    public function getType($classIdentifier)
+    public function registerExposableTypeProperty(ExposableType $exposableType, $propertyName, $propertyType)
     {
-        if (array_key_exists($classIdentifier, $this->classIdentifierToTypeNameMap)) {
-            return $this->classIdentifierToTypeNameMap[$classIdentifier];
-        } else {
-            throw new FormatNotSupportedException('There is no target type for class name "' . $classIdentifier . '"',
-                1451995790);
-        }
+        $propertyIdentifier = $exposableType->getVersionType() . '->' . $propertyName;
+        $this->typeAndPropertyNameToClassIdentifierMap[$propertyIdentifier] = $propertyType;
     }
 
-    /**
-     * @param string $typeName
-     * @return string
-     * @throws FormatNotSupportedException
-     */
-    public function getClassName($typeName)
+    public function getExposableTypeByClassIdentifier(string $classIdentifier): ExposableType
     {
-        if (array_key_exists($typeName, $this->typeNameToClassIdentifierMap)) {
-            return $this->typeNameToClassIdentifierMap[$typeName];
-        } else {
-            throw new FormatNotSupportedException('There is no target class name for type "' . $typeName . '"',
-                1451995976);
-        }
+        return $this->classIdentifierToTypeNameMap[$classIdentifier] ?? throw new FormatNotSupportedException(
+            'There is no target type for class name "' . $classIdentifier . '"',
+            1451995790
+        );
     }
 
-    /**
-     * @param string $typeName
-     * @param string $propertyName
-     * @return string
-     * @throws FormatNotSupportedException
-     */
-    public function getClassNameForProperty($typeName, $propertyName)
+    public function getExposableTypeByTypeName(string $typeName, string $apiVersion): ExposableType
     {
+        $apiVersion = self::$forcedApiVersion ?? $apiVersion;
+        return $this->typeNameToClassIdentifierMap[$typeName][$apiVersion] ?? throw new FormatNotSupportedException(
+            'There is no target class name for type "' . $typeName . '" with api version "' . $apiVersion . '"',
+            1451995976
+        );
+    }
+
+    public function getExposableTypeByVersionedTypeName(string $versionedTypeName): ExposableType
+    {
+        if (self::$forcedApiVersion) {
+            $versionedTypeName = explode('@', $versionedTypeName)[0];
+            if (self::$forcedApiVersion !== ExposableTypeMapInterface::NEXT_VERSION) {
+                $versionedTypeName .= '@' . self::$forcedApiVersion;
+            }
+        }
+        return $this->oneToOneTypeToClassMap[$versionedTypeName] ?? throw new FormatNotSupportedException(
+            'There is no target class name for type "' . $versionedTypeName . '"',
+            1758629156
+        );
+    }
+
+    public function getPropertyType(
+        string $typeName,
+        string $apiVersion,
+        string $propertyName
+    ): string {
+        $apiVersion = self::$forcedApiVersion ?? $apiVersion;
         $key = strtolower($typeName . '->' . $propertyName);
         if (array_key_exists($key, $this->typeAndPropertyNameToClassIdentifierMap)) {
             return $this->typeAndPropertyNameToClassIdentifierMap[$key];
         } else {
-            throw new FormatNotSupportedException('There is no target class name for property "' . $key . '"',
-                1560943398);
+            throw new FormatNotSupportedException(
+                'There is no target class name for property "' . $key . '" with api version "' . $apiVersion . '"',
+                1560943398
+            );
+        }
+    }
+
+    final public static function forceApiVersion(?string $apiVersion, callable $do): mixed
+    {
+        $apiVersionBefore = static::$forcedApiVersion;
+        static::$forcedApiVersion = $apiVersion ?? ExposableTypeMapInterface::NEXT_VERSION;
+        try {
+            return $do();
+        } finally {
+            static::$forcedApiVersion = $apiVersionBefore;
         }
     }
 

--- a/Classes/Netlogix/JsonApiOrg/Resource/Information/ExposableTypeMapInterface.php
+++ b/Classes/Netlogix/JsonApiOrg/Resource/Information/ExposableTypeMapInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Netlogix\JsonApiOrg\Resource\Information;
 
 /*
@@ -24,29 +25,21 @@ use Neos\Flow\Property\Exception\FormatNotSupportedException;
  */
 interface ExposableTypeMapInterface
 {
+    public const string NEXT_VERSION = 'next';
+
+    public function getExposableTypeByClassIdentifier(string $classIdentifier): ExposableType;
+
+    public function getExposableTypeByTypeName(string $typeName, string $apiVersion): ExposableType;
+
+    public function getExposableTypeByVersionedTypeName(string $versionedTypeName): ExposableType;
+
+    public function getPropertyType(string $typeName, string $apiVersion, string $propertyName): string;
 
     /**
-     * Returns the public type string for a given class name.
-     *
-     * @param string $classIdentifier
-     * @return string
-     * @throws FormatNotSupportedException
+     * @template T
+     * @param callable():T $do
+     * @return T
      */
-    public function getType($classIdentifier);
-
-    /**
-     * @param string $typeName
-     * @return string
-     * @throws FormatNotSupportedException
-     */
-    public function getClassName($typeName);
-
-    /**
-     * @param string $typeName
-     * @param string $propertyName
-     * @return string
-     * @throws FormatNotSupportedException
-     */
-    public function getClassNameForProperty($typeName, $propertyName);
+    public static function forceApiVersion(string $apiVersion, callable $do): mixed;
 
 }

--- a/Classes/Netlogix/JsonApiOrg/Resource/Information/ResourceInformation.php
+++ b/Classes/Netlogix/JsonApiOrg/Resource/Information/ResourceInformation.php
@@ -12,6 +12,8 @@ namespace Netlogix\JsonApiOrg\Resource\Information;
 use GuzzleHttp\Psr7\Uri;
 use Netlogix\JsonApiOrg\Domain\Dto\AbstractResource;
 use Neos\Flow\Annotations as Flow;
+use Netlogix\JsonApiOrg\Schema;
+use Psr\Http\Message\UriInterface;
 
 /**
  * The ResourceInformation is a mapping schema for bringing
@@ -102,19 +104,12 @@ abstract class ResourceInformation
      *
      * @return int
      */
-    public function getPriority()
+    public function getPriority(): int
     {
         return $this->priority;
     }
 
-    /**
-     * Here, the DtoConverter can do some additional runtime checks to see whether
-     * it can handle the given source data.
-     *
-     * @param mixed $payload the source data
-     * @return boolean TRUE if this DtoConverter can handle the $source, FALSE otherwise.
-     */
-    public function canHandle($payload)
+    public function canHandle(mixed $payload): bool
     {
         if (is_object($payload) && is_a($payload, $this->payloadClassName)) {
             return true;
@@ -125,69 +120,42 @@ abstract class ResourceInformation
         }
     }
 
-    /**
-     * @param mixed $payload
-     * @return \Netlogix\JsonApiOrg\Schema\Resource
-     */
-    public function getResource($payload)
+    public function getResource(mixed $payload): Schema\Resource
     {
-        return $this->objectManager->get($this->resourceClassName, $payload, $this);
+        $resource = $this->objectManager->get($this->resourceClassName, $payload, $this);
+        assert($resource instanceof Schema\Resource);
+        return $resource;
     }
 
-    /**
-     * For every $resource to be handled, a Converter needs to be able to create
-     * a public URI pointing at the index action.
-     * So the Converter is used for both, exposing the API of a distinct object
-     * type to the public as well as creating internal sub requests for related
-     * objects.
-     *
-     * @param mixed $resource
-     * @return Uri
-     */
-    public function getPublicResourceUri($resource)
+    public function getPublicResourceUri(mixed $resource): Uri
     {
-        return $this->getPublicUri($resource, $this->resourceControllerActionName,
-            $this->getResourceControllerArguments($resource));
+        return $this->getPublicUri(
+            $resource,
+            $this->resourceControllerActionName,
+            $this->getResourceControllerArguments($resource)
+        );
     }
 
-    /**
-     * For every $resource to be handled, a Converter needs to be able to create
-     * a public URI pointing at an action showing information about an individual
-     * relationship.
-     *
-     * @param mixed $resource
-     * @param string $relationshipName
-     *
-     * @return Uri
-     */
-    public function getPublicRelationshipUri($resource, $relationshipName)
+    public function getPublicRelationshipUri(mixed $resource, string $relationshipName): Uri
     {
-        return $this->getPublicUri($resource, $this->resourceControllerActionName,
-            $this->getRelationshipControllerArguments($resource, $relationshipName));
+        return $this->getPublicUri(
+            $resource,
+            $this->resourceControllerActionName,
+            $this->getRelationshipControllerArguments($resource, $relationshipName)
+        );
     }
 
-    /**
-     * For every $resource to be handled, a Converter needs to be able to create
-     * a public URI pointing at an action showing information about an individual
-     * relationship.
-     *
-     * @param mixed $resource
-     * @param string $relationshipName
-     *
-     * @return Uri
-     */
-    public function getPublicRelatedUri($resource, $relationshipName)
+    public function getPublicRelatedUri(mixed $resource, string $relationshipName): Uri
     {
-        return $this->getPublicUri($resource, $this->relatedControllerActionName,
-            $this->getRelationshipControllerArguments($resource, $relationshipName));
+        $x = $this->getPublicUri(
+            $resource,
+            $this->relatedControllerActionName,
+            $this->getRelationshipControllerArguments($resource, $relationshipName)
+        );
+        return $x;
     }
 
-    /**
-     * Get a UriBuilder for creating URIs for a resource.
-     *
-     * @return \Neos\Flow\Mvc\Routing\UriBuilder
-     */
-    public function getUriBuilder()
+    public function getUriBuilder(): \Neos\Flow\Mvc\Routing\UriBuilder
     {
         $uriBuilder = $this->resourceMapper->getControllerContext()->getUriBuilder();
 
@@ -197,27 +165,27 @@ abstract class ResourceInformation
     }
 
     /**
-     * @param mixed $resource
-     * @param string $controllerActionName
-     * @param array $controllerArguments
-     * @return Uri
+     * @param array<mixed, mixed> $controllerArguments
      */
-    protected function getPublicUri($resource, $controllerActionName, array $controllerArguments = array())
+    protected function getPublicUri(mixed $resource, string $controllerActionName, array $controllerArguments = array()): UriInterface
     {
         $uriBuilder = $this->getUriBuilder();
 
-        $uri = $uriBuilder->uriFor($controllerActionName,
-            array_merge($this->getResourceControllerArguments($resource), $controllerArguments), $this->controllerName,
-            $this->packageKey, $this->subPackageKey);
+        $uri = $uriBuilder->uriFor(
+            $controllerActionName,
+            array_merge($this->getResourceControllerArguments($resource), $controllerArguments),
+            $this->controllerName,
+            $this->packageKey,
+            $this->subPackageKey
+        );
 
         return new Uri($uri);
     }
 
     /**
-     * @param mixed $resource
-     * @return array
+     * @return array<string, mixed>
      */
-    public function getResourceControllerArguments($resource)
+    public function getResourceControllerArguments(mixed $resource): array
     {
         return array(
             'resource' => $resource,
@@ -225,15 +193,13 @@ abstract class ResourceInformation
     }
 
     /**
-     * @param mixed $resource
-     * @param string $relationshipName
-     * @return array
+     * @return array<string, mixed>
      */
-    protected function getRelationshipControllerArguments($resource, $relationshipName)
+    protected function getRelationshipControllerArguments(mixed $resource, string $relationshipName): array
     {
         return array(
             'resource' => $resource,
-            'relationshipName' => $relationshipName
+            'relationshipName' => $relationshipName,
         );
     }
 

--- a/Classes/Netlogix/JsonApiOrg/Resource/Information/ResourceInformationInterface.php
+++ b/Classes/Netlogix/JsonApiOrg/Resource/Information/ResourceInformationInterface.php
@@ -26,19 +26,14 @@ interface ResourceInformationInterface
 
     /**
      * Return the priority of this DtoConverter. DtoConverters with a high priority are chosen before low priority.
-     *
-     * @return int
      */
-    public function getPriority();
+    public function getPriority(): int;
 
     /**
      * Here, the DtoConverter can do some additional runtime checks to see whether
      * it can handle the given source data.
-     *
-     * @param mixed $payload the source data
-     * @return boolean TRUE if this DtoConverter can handle the $source, FALSE otherwise.
      */
-    public function canHandle($payload);
+    public function canHandle(mixed $payload): bool;
 
     /**
      * @param mixed $payload
@@ -52,27 +47,19 @@ interface ResourceInformationInterface
      * So the Converter is used for both, exposing the API of a distinct object
      * type to the public as well as creating internal sub requests for related
      * objects.
-     *
-     * @param mixed $resource
-     * @return UriInterface
      */
-    public function getPublicResourceUri($resource);
+    public function getPublicResourceUri(mixed $resource): UriInterface;
 
     /**
      * For every $resource to be handled, a Converter needs to be able to create
      * a public URI pointing at an action showing information about an individual
      * relationship.
-     *
-     * @param mixed $payload
-     * @param string $relationshipName
-     * @return UriInterface
      */
-    public function getPublicRelatedUri($payload, $relationshipName);
+    public function getPublicRelatedUri(mixed $payload, string $relationshipName): UriInterface;
 
     /**
-     * @param mixed $payload
-     * @return array
+     * @return array<string, mixed>
      */
-    public function getResourceControllerArguments($payload);
+    public function getResourceControllerArguments(mixed $payload): array;
 
 }

--- a/Classes/Netlogix/JsonApiOrg/Resource/Information/ResourceMapper.php
+++ b/Classes/Netlogix/JsonApiOrg/Resource/Information/ResourceMapper.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Netlogix\JsonApiOrg\Resource\Information;
 
 /*
@@ -8,6 +9,7 @@ namespace Netlogix\JsonApiOrg\Resource\Information;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
+
 use Netlogix\JsonApiOrg\Exceptions\ResourceInformationNotFound;
 use Netlogix\JsonApiOrg\Property\TypeConverter\SchemaResource\ResourceConverter;
 use Netlogix\JsonApiOrg\Schema;
@@ -91,16 +93,19 @@ class ResourceMapper
      * The controllerContext is added to the resource information object to allow
      * it to create proper URIs.
      *
-     * @todo Use runtime cache based on spl_object_hash
      * @param mixed $payload
      * @return \Netlogix\JsonApiOrg\Resource\Information\ResourceInformationInterface
+     * @todo Use runtime cache based on spl_object_hash
      */
     public function findResourceInformation($payload)
     {
-
         if (is_array($payload) && isset($payload['type']) && isset($payload['id'])) {
-            $payload = $this->propertyMapper->convert((string)$payload['id'],
-                $this->exposableTypeMap->getClassName($payload['type']));
+            $payload = $this->propertyMapper->convert(
+                (string)$payload['id'],
+                $this->exposableTypeMap
+                    ->getExposableTypeByVersionedTypeName($payload['type'])
+                    ->className
+            );
         }
 
         /** @var ResourceInformationInterface $resourceInformation */
@@ -131,11 +136,13 @@ class ResourceMapper
                 1740128675
             );
         }
-        
+
         $resource = $resourceInformation->getResource($payload);
 
         return array(
-            'type' => $this->exposableTypeMap->getType($resource->getType()),
+            'type' => $this->exposableTypeMap
+                ->getExposableTypeByClassIdentifier($resource->getType())
+                ->getVersionType(),
             'id' => $resource->getId()
         );
     }
@@ -177,20 +184,25 @@ class ResourceMapper
      */
     protected function initializeConverters()
     {
-
         $this->resourceInformation = array();
 
-        foreach ($this->reflectionService->getAllImplementationClassNamesForInterface(ResourceInformationInterface::class) as $resourceInformationClassName) {
+        foreach (
+            $this->reflectionService->getAllImplementationClassNamesForInterface(
+                ResourceInformationInterface::class
+            ) as $resourceInformationClassName
+        ) {
             $this->resourceInformation[] = $this->objectManager->get($resourceInformationClassName);
         }
-        usort($this->resourceInformation,
+        usort(
+            $this->resourceInformation,
             function (ResourceInformationInterface $first, ResourceInformationInterface $second) {
                 if ($first->getPriority() == $second->getPriority()) {
                     return strcmp(TypeHandling::getTypeForValue($first), TypeHandling::getTypeForValue($second));
                 } else {
                     return $first->getPriority() < $second->getPriority();
                 }
-            });
+            }
+        );
     }
 
     public function withinControllerContext(ControllerContext $controllerContext, callable $scope)

--- a/Classes/Netlogix/JsonApiOrg/Resource/RelationshipIterator.php
+++ b/Classes/Netlogix/JsonApiOrg/Resource/RelationshipIterator.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Netlogix\JsonApiOrg\Resource;
 
 /*
@@ -72,7 +73,6 @@ class RelationshipIterator
      */
     public function createTopLevel($resource)
     {
-
         $this->initializeResourceResolver();
         $this->initializeStack($resource);
 
@@ -120,7 +120,6 @@ class RelationshipIterator
      */
     protected function createResult($singleResource)
     {
-
         $result = new TopLevel($singleResource);
 
         foreach ($this->stack->getResults() as $resourceWorkloadPackage) {
@@ -165,7 +164,6 @@ class RelationshipIterator
         $relationshipsToBeApiExposed = $resource->getRelationshipsToBeApiExposed();
 
         foreach ($resource->getRelationships() as $relationshipName => $relationshipContent) {
-
             if (!$resource->getRelationships()->isAllowedIncludeField($relationshipName)) {
                 continue;
             }
@@ -185,7 +183,6 @@ class RelationshipIterator
                         $this->pushRelation($relation, $relationshipNestingPaths);
                     }
                     break;
-
             }
         }
     }
@@ -220,7 +217,10 @@ class RelationshipIterator
      */
     protected function getEffectiveFieldsForResource(ResourceInterface $resource)
     {
-        $type = $this->exposableTypeMap->getType($resource->getType());
+        $type = $this
+            ->exposableTypeMap
+            ->getExposableTypeByClassIdentifier($resource->getType())
+            ->getVersionType();
         if (array_key_exists($type, $this->fields)) {
             return $this->fields[$type];
         }
@@ -312,7 +312,9 @@ class RelationshipIterator
      */
     private function isArray($resource)
     {
-        return is_array($resource) || (is_object($resource) && $resource instanceof Collection) || (is_object($resource) && $resource instanceof QueryResultInterface);
+        return is_array($resource)
+            || (is_object($resource) && $resource instanceof Collection)
+            || (is_object($resource) && $resource instanceof QueryResultInterface);
     }
 
 }

--- a/Classes/Netlogix/JsonApiOrg/Resource/RequestStack.php
+++ b/Classes/Netlogix/JsonApiOrg/Resource/RequestStack.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Netlogix\JsonApiOrg\Resource;
 
 /*
@@ -58,7 +59,6 @@ class RequestStack
         if (array_key_exists($hash, $this->results)) {
             $this->results[$hash][self::RESULT_NESTING_PATHS][$nestingPath] = $nestingPath;
             return;
-
         }
         $this->results[$hash] = [
             self::RESULT_RESOURCE => $resource,
@@ -76,7 +76,13 @@ class RequestStack
      */
     public function pushIdentifier(array $identifier, $position = self::POSITION_INCLUDE, $nestingPath = '')
     {
-        $resource = $this->propertyMapper->convert((string)$identifier['id'], $this->exposableTypeMap->getClassName($identifier['type']));
+        $resource = $this->propertyMapper
+            ->convert(
+                source: (string)$identifier['id'],
+                targetType: $this->exposableTypeMap
+                    ->getExposableTypeByVersionedTypeName($identifier['type'])
+                    ->className
+            );
         $this->push($resource, $position, $nestingPath);
     }
 


### PR DESCRIPTION
Now a single json api type can be configured multipe times, as long as it comes with different version strings.

Replace internal array configuration with ExposableType object, which is named after the ExposeType annotation already prsent in the AnnotationGeneric package.